### PR TITLE
Remove unnecessary usings from startup

### DIFF
--- a/AspNetCoreMediatRExample/Startup.cs
+++ b/AspNetCoreMediatRExample/Startup.cs
@@ -1,12 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
Removed extra namespaces from the `Startup` file.
They weren't needed, and Ryan needs me to test the repo permissions.